### PR TITLE
Bugfix #1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
                 "--verbose"
             ]
         }
-    ]
+    ],
+    "latex-workshop.latex.autoBuild.cleanAndRetry.enabled": false
 }

--- a/Thesis.tex
+++ b/Thesis.tex
@@ -193,9 +193,7 @@
   \begingroup
     \let\clearpage\relax
     \glsaddall
-    \printglossary[type=\acronymtype]
-    \newpage
-    \printglossary
+    % \printglossary[type=\acronymtype]
   \endgroup
 
   \printindex


### PR DESCRIPTION
Extended setting.json to avoid automatic build on error.
Tracking down the issue for build error; obviously caused by \printglossary.